### PR TITLE
change outputDirectory to not be hardcoded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 replay_pid*
+
+server/

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>2.3.1</version>
                 <configuration>
-                    <outputDirectory>F:\testovací server\plugins</outputDirectory>
+                    <outputDirectory>${basedir}/server/plugins</outputDirectory>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
make the outputDirectory in ${basedir}/server/plugins instead of a hardcoded path, make the server directory excluded in .gitignore